### PR TITLE
chore: complete Chakra UI v3 migration

### DIFF
--- a/client-app/src/Layouts/ActivitiesLayout.tsx
+++ b/client-app/src/Layouts/ActivitiesLayout.tsx
@@ -1,4 +1,10 @@
-import { Box, Flex, Link, Text, useColorModeValue } from "@chakra-ui/react";
+import {
+	Box,
+	Flex,
+	Link,
+	Text,
+} from "@chakra-ui/react";
+import { useColorModeValue } from "../components/ui/color-mode";
 import { Outlet } from "react-router-dom";
 import Navbar from "../components/Navbar";
 

--- a/client-app/src/async/fetcher/index.ts
+++ b/client-app/src/async/fetcher/index.ts
@@ -1,4 +1,8 @@
-import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
+import axios, {
+	AxiosError,
+	AxiosResponse,
+	InternalAxiosRequestConfig,
+} from "axios";
 import { PaginationResults } from "~/lib/PaginationResults";
 import { store } from "~/stores/store";
 import { sleep } from "../../utils/sleeper";
@@ -7,7 +11,7 @@ const instance = axios.create({
 	baseURL: import.meta.env.VITE_API_URL,
 });
 
-instance.interceptors.request.use((config: AxiosRequestConfig<unknown>) => {
+instance.interceptors.request.use((config: InternalAxiosRequestConfig) => {
 	const token = store.commonStore.token;
 	if (token) {
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -40,9 +44,8 @@ instance.interceptors.response.use(
 			case 400:
 				if (typeof data === "string") {
 					window?.toast({
-						status: "error",
+						type: "error",
 						title: "Bad request, try again later.",
-						position: "bottom-right",
 					});
 				}
 				// eslint-disable-next-line no-prototype-builtins
@@ -66,9 +69,8 @@ instance.interceptors.response.use(
 				) {
 					store.userStore.logout();
 					window?.toast({
-						status: "error",
+						type: "error",
 						title: "Session expired - please login",
-						position: "bottom-right",
 					});
 				}
 				break;

--- a/client-app/src/components/CalendarDate.tsx
+++ b/client-app/src/components/CalendarDate.tsx
@@ -1,4 +1,8 @@
-import { Box, Flex, useColorModeValue } from "@chakra-ui/react";
+import {
+	Box,
+	Flex,
+} from "@chakra-ui/react";
+import { useColorModeValue } from "./ui/color-mode";
 import dayjs from "dayjs";
 import { useMemo } from "react";
 
@@ -18,7 +22,7 @@ const CalendarDate = ({ date }: Props) => {
 		<Flex mr={3} flexDir="column" textAlign="center" borderRadius="md" w="3.125rem">
 			<Box
 				bgColor="red.500"
-				textColor="white"
+				color="white"
 				borderTopRadius=".375rem"
 				p={1}
 				fontWeight="semibold"
@@ -28,7 +32,7 @@ const CalendarDate = ({ date }: Props) => {
 			</Box>
 			<Box
 				borderTopColor="initial"
-				textColor={useColorModeValue("gray.700", "gray.100")}
+				color={useColorModeValue("gray.700", "gray.100")}
 				fontSize="2xl"
 				p={".15rem"}
 				border=".125rem solid var(--chakra-colors-red-500)"

--- a/client-app/src/components/DesktopNav.tsx
+++ b/client-app/src/components/DesktopNav.tsx
@@ -1,4 +1,4 @@
-import { ChevronRightIcon } from "@chakra-ui/icons";
+import { ChevronRightIcon } from "@heroicons/react/24/outline";
 import {
 	Box,
 	Button,
@@ -6,14 +6,13 @@ import {
 	Icon,
 	Link as CLINK,
 	Popover,
-	PopoverContent,
-	PopoverTrigger,
+	Portal,
 	Stack,
 	Text,
-	useColorModeValue,
 } from "@chakra-ui/react";
-import { NavItem, NAV_ITEMS } from "./MobileNav";
 import { Link, NavLink } from "react-router-dom";
+import { NAV_ITEMS, type NavItem } from "./MobileNav";
+import { useColorModeValue } from "./ui/color-mode";
 
 const DesktopNav = () => {
 	const linkColor = useColorModeValue("gray.600", "gray.200");
@@ -21,12 +20,13 @@ const DesktopNav = () => {
 	const popoverContentBgColor = useColorModeValue("white", "gray.800");
 
 	return (
-		<Stack direction={"row"} spacing={4} alignItems="center">
+		<Stack direction={"row"} gap={4} alignItems="center">
 			{NAV_ITEMS.map((navItem) => (
 				<Box key={navItem.label}>
-					<Popover trigger={"hover"} placement={"bottom-start"}>
-						<PopoverTrigger>
+					<Popover.Root positioning={{ placement: "bottom-start" }}>
+						<Popover.Trigger asChild>
 							<CLINK
+								asChild
 								p={2}
 								fontSize={"sm"}
 								fontWeight={500}
@@ -35,34 +35,39 @@ const DesktopNav = () => {
 									textDecoration: "none",
 									color: linkHoverColor,
 								}}
-								as={NavLink}
-								to={navItem.href ?? "#"}
 							>
-								{navItem.label}
+								<NavLink to={navItem.href ?? "#"}>{navItem.label}</NavLink>
 							</CLINK>
-						</PopoverTrigger>
+						</Popover.Trigger>
 
 						{navItem.children && (
-							<PopoverContent
-								border={0}
-								boxShadow={"xl"}
-								bg={popoverContentBgColor}
-								p={4}
-								rounded={"xl"}
-								minW={"sm"}
-							>
-								<Stack>
-									{navItem.children.map((child) => (
-										<DesktopSubNav key={child.label} {...child} />
-									))}
-								</Stack>
-							</PopoverContent>
+							<Portal>
+								<Popover.Positioner>
+									<Popover.Content
+										border={0}
+										boxShadow={"xl"}
+										bg={popoverContentBgColor}
+										p={4}
+										rounded={"xl"}
+										minW={"sm"}
+									>
+										<Popover.Body p={0}>
+											<Stack>
+												{navItem.children.map((child) => (
+													<DesktopSubNav key={child.label} {...child} />
+												))}
+											</Stack>
+										</Popover.Body>
+									</Popover.Content>
+								</Popover.Positioner>
+							</Portal>
 						)}
-					</Popover>
+					</Popover.Root>
 				</Box>
 			))}
 			<Box>
 				<Button
+					asChild
 					p={2}
 					fontSize={"sm"}
 					fontWeight={500}
@@ -71,10 +76,8 @@ const DesktopNav = () => {
 						textDecoration: "none",
 						color: linkHoverColor,
 					}}
-					as={Link}
-					to={"/activities/create"}
 				>
-					Create Activity
+					<Link to={"/activities/create"}>Create Activity</Link>
 				</Button>
 			</Box>
 		</Stack>
@@ -82,6 +85,7 @@ const DesktopNav = () => {
 };
 
 const DesktopSubNav = ({ label, href, subLabel }: NavItem) => {
+	const hoverBg = useColorModeValue("pink.50", "gray.900");
 	return (
 		<CLINK
 			href={href}
@@ -89,7 +93,7 @@ const DesktopSubNav = ({ label, href, subLabel }: NavItem) => {
 			display={"block"}
 			p={2}
 			rounded={"md"}
-			_hover={{ bg: useColorModeValue("pink.50", "gray.900") }}
+			_hover={{ bg: hoverBg }}
 		>
 			<Stack direction={"row"} align={"center"}>
 				<Box>
@@ -107,7 +111,9 @@ const DesktopSubNav = ({ label, href, subLabel }: NavItem) => {
 					align={"center"}
 					flex={1}
 				>
-					<Icon color={"pink.400"} w={5} h={5} as={ChevronRightIcon} />
+					<Icon color={"pink.400"} w={5} h={5}>
+						<ChevronRightIcon />
+					</Icon>
 				</Flex>
 			</Stack>
 		</CLINK>

--- a/client-app/src/components/MobileNav.tsx
+++ b/client-app/src/components/MobileNav.tsx
@@ -1,18 +1,19 @@
-import { ChevronDownIcon } from "@chakra-ui/icons";
+import { ChevronDownIcon } from "@heroicons/react/24/outline";
 import {
-	Collapse,
+	Collapsible,
 	Flex,
 	Icon,
 	Link,
 	Stack,
 	Text,
-	useColorModeValue,
 	useDisclosure,
 } from "@chakra-ui/react";
+import { useColorModeValue } from "./ui/color-mode";
 
 export const MobileNav = () => {
+	const bg = useColorModeValue("white", "gray.800");
 	return (
-		<Stack bg={useColorModeValue("white", "gray.800")} p={4} display={{ md: "none" }}>
+		<Stack bg={bg} p={4} display={{ md: "none" }}>
 			{NAV_ITEMS.map((navItem) => (
 				<MobileNavItem key={navItem.label} {...navItem} />
 			))}
@@ -21,51 +22,57 @@ export const MobileNav = () => {
 };
 
 const MobileNavItem = ({ label, children, href }: NavItem) => {
-	const { isOpen, onToggle } = useDisclosure();
+	const { open, onToggle } = useDisclosure();
+	const textColor = useColorModeValue("gray.600", "gray.200");
+	const borderColor = useColorModeValue("gray.200", "gray.700");
 
 	return (
-		<Stack spacing={4} onClick={children && onToggle}>
+		<Stack gap={4} onClick={children && onToggle}>
 			<Flex
+				asChild
 				py={2}
-				as={Link}
-				href={href ?? "#"}
 				justify={"space-between"}
 				align={"center"}
 				_hover={{
 					textDecoration: "none",
 				}}
 			>
-				<Text fontWeight={600} color={useColorModeValue("gray.600", "gray.200")}>
-					{label}
-				</Text>
-				{children && (
-					<Icon
-						as={ChevronDownIcon}
-						transition={"all .25s ease-in-out"}
-						transform={isOpen ? "rotate(180deg)" : ""}
-						w={6}
-						h={6}
-					/>
-				)}
+				<a href={href ?? "#"}>
+					<Text fontWeight={600} color={textColor}>
+						{label}
+					</Text>
+					{children && (
+						<Icon
+							transition={"all .25s ease-in-out"}
+							transform={open ? "rotate(180deg)" : ""}
+							w={6}
+							h={6}
+						>
+							<ChevronDownIcon />
+						</Icon>
+					)}
+				</a>
 			</Flex>
 
-			<Collapse in={isOpen} animateOpacity style={{ marginTop: "0!important" }}>
-				<Stack
-					mt={2}
-					pl={4}
-					borderLeft={1}
-					borderStyle={"solid"}
-					borderColor={useColorModeValue("gray.200", "gray.700")}
-					align={"start"}
-				>
-					{children &&
-						children.map((child) => (
-							<Link key={child.label} py={2} href={child.href}>
-								{child.label}
-							</Link>
-						))}
-				</Stack>
-			</Collapse>
+			<Collapsible.Root open={open} style={{ marginTop: "0!important" }}>
+				<Collapsible.Content>
+					<Stack
+						mt={2}
+						pl={4}
+						borderLeft={1}
+						borderStyle={"solid"}
+						borderColor={borderColor}
+						align={"start"}
+					>
+						{children &&
+							children.map((child) => (
+								<Link key={child.label} py={2} href={child.href}>
+									{child.label}
+								</Link>
+							))}
+					</Stack>
+				</Collapsible.Content>
+			</Collapsible.Root>
 		</Stack>
 	);
 };

--- a/client-app/src/components/Navbar.tsx
+++ b/client-app/src/components/Navbar.tsx
@@ -1,46 +1,49 @@
-import { CloseIcon, HamburgerIcon, MoonIcon, SunIcon } from "@chakra-ui/icons";
+import { Bars3Icon, MoonIcon, SunIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import {
-	Avatar,
 	Box,
 	Button,
-	Collapse,
+	Collapsible,
 	Flex,
 	IconButton,
 	Menu,
-	MenuButton,
-	MenuItem,
-	MenuList,
+	Portal,
 	Stack,
 	Text,
 	useBreakpointValue,
-	useColorMode,
-	useColorModeValue,
 	useDisclosure,
 } from "@chakra-ui/react";
 import { observer } from "mobx-react-lite";
 import { Link, NavLink } from "react-router-dom";
 import { useStoreContext } from "~/stores/store";
+import { Avatar } from "./ui/avatar";
+import { useColorMode, useColorModeValue } from "./ui/color-mode";
 import DesktopNav from "./DesktopNav";
 import { MobileNav } from "./MobileNav";
 
 const Navbar = () => {
 	const { colorMode, toggleColorMode } = useColorMode();
-	const { isOpen, onToggle } = useDisclosure();
+	const { open, onToggle } = useDisclosure();
 	const {
 		userStore: { user, logout },
 	} = useStoreContext();
 
+	const bg = useColorModeValue("white", "gray.800");
+	const color = useColorModeValue("gray.600", "white");
+	const borderColor = useColorModeValue("gray.200", "gray.900");
+	const headingColor = useColorModeValue("gray.800", "white");
+	const textAlign = useBreakpointValue({ base: "center", md: "left" } as const);
+
 	return (
 		<Box>
 			<Flex
-				bg={useColorModeValue("white", "gray.800")}
-				color={useColorModeValue("gray.600", "white")}
+				bg={bg}
+				color={color}
 				minH={"60px"}
 				py={{ base: 2 }}
 				px={{ base: 8 }}
 				borderBottom={1}
 				borderStyle={"solid"}
-				borderColor={useColorModeValue("gray.200", "gray.900")}
+				borderColor={borderColor}
 				align={"center"}
 			>
 				<Flex
@@ -50,20 +53,20 @@ const Navbar = () => {
 				>
 					<IconButton
 						onClick={onToggle}
-						icon={isOpen ? <CloseIcon w={3} h={3} /> : <HamburgerIcon w={5} h={5} />}
 						variant={"ghost"}
 						aria-label={"Toggle Navigation"}
-					/>
+					>
+						{open ? <XMarkIcon width={12} height={12} /> : <Bars3Icon width={20} height={20} />}
+					</IconButton>
 				</Flex>
 				<Flex flex={{ base: 1 }} justify={{ base: "center", md: "start" }} alignItems="center">
 					<Text
-						as={NavLink}
-						to="/"
-						textAlign={useBreakpointValue({ base: "center", md: "left" })}
+						asChild
+						textAlign={textAlign}
 						fontFamily={"heading"}
-						color={useColorModeValue("gray.800", "white")}
+						color={headingColor}
 					>
-						Reactivities
+						<NavLink to="/">Reactivities</NavLink>
 					</Text>
 
 					<Flex display={{ base: "none", md: "flex" }} alignItems="center" ml={10}>
@@ -76,15 +79,15 @@ const Navbar = () => {
 					justify={"flex-end"}
 					alignItems="center"
 					direction={"row"}
-					spacing={6}
+					gap={6}
 				>
 					<Button onClick={toggleColorMode} variant="ghost" size="sm">
-						{colorMode === "light" ? <MoonIcon /> : <SunIcon />}
+						{colorMode === "light" ? <MoonIcon width={20} height={20} /> : <SunIcon width={20} height={20} />}
 					</Button>
 					{!user ? (
 						<>
-							<Button as={Link} fontSize={"sm"} fontWeight={400} variant={"link"} to={"/login"}>
-								Sign In
+							<Button asChild fontSize={"sm"} fontWeight={400} variant={"plain"}>
+								<Link to={"/login"}>Sign In</Link>
 							</Button>
 							<Button
 								display={{ base: "none", md: "inline-flex" }}
@@ -100,26 +103,34 @@ const Navbar = () => {
 							</Button>
 						</>
 					) : (
-						<>
-							<Menu>
-								<MenuButton>
+						<Menu.Root>
+							<Menu.Trigger asChild>
+								<Box as="button" cursor="pointer">
 									<Avatar size="sm" name={user?.displayName} src={user?.image} />
-								</MenuButton>
-								<MenuList>
-									<MenuItem as={Link} to={`/profiles/${user?.username}`}>
-										Profile
-									</MenuItem>
-									<MenuItem onClick={logout}>Logout</MenuItem>
-								</MenuList>
-							</Menu>
-						</>
+								</Box>
+							</Menu.Trigger>
+							<Portal>
+								<Menu.Positioner>
+									<Menu.Content>
+										<Menu.Item value="profile" asChild>
+											<Link to={`/profiles/${user?.username}`}>Profile</Link>
+										</Menu.Item>
+										<Menu.Item value="logout" onClick={logout}>
+											Logout
+										</Menu.Item>
+									</Menu.Content>
+								</Menu.Positioner>
+							</Portal>
+						</Menu.Root>
 					)}
 				</Stack>
 			</Flex>
 
-			<Collapse in={isOpen} animateOpacity>
-				<MobileNav />
-			</Collapse>
+			<Collapsible.Root open={open}>
+				<Collapsible.Content>
+					<MobileNav />
+				</Collapsible.Content>
+			</Collapsible.Root>
 		</Box>
 	);
 };

--- a/client-app/src/components/ScreenLoading.tsx
+++ b/client-app/src/components/ScreenLoading.tsx
@@ -18,7 +18,12 @@ const ScreenLoading = ({ content = "Loading..." }: Props) => {
 			w="100vw"
 			h="100vh"
 		>
-			<Spinner thickness="4px" speed="0.65s" emptyColor="gray.200" color="blue.500" size="xl" />
+			<Spinner
+				borderWidth="4px"
+				animationDuration="0.65s"
+				color="blue.500"
+				size="xl"
+			/>
 			<Text>{content}</Text>
 		</Flex>
 	);

--- a/client-app/src/components/forms/Input.tsx
+++ b/client-app/src/components/forms/Input.tsx
@@ -1,14 +1,7 @@
-import {
-	FormControl,
-	VisuallyHidden,
-	FormLabel,
-	Input,
-	FormErrorMessage,
-	InputProps,
-	useColorModeValue,
-} from "@chakra-ui/react";
+import { Input, type InputProps, VisuallyHidden } from "@chakra-ui/react";
 import { useField } from "formik";
-import React from "react";
+import { Field } from "../ui/field";
+import { useColorModeValue } from "../ui/color-mode";
 
 type Props = InputProps & {
 	name: string;
@@ -18,14 +11,17 @@ type Props = InputProps & {
 const InputField = (props: Props) => {
 	const [field, meta] = useField(props.name as string);
 	const isInvalid = Boolean(meta.touched && meta.error);
+	const bg = useColorModeValue("gray.100", "gray.300");
 	return (
-		<FormControl id={props.name} isInvalid={isInvalid}>
-			<VisuallyHidden>
-				<FormLabel>{props.name}</FormLabel>
-			</VisuallyHidden>
+		<Field
+			id={props.name}
+			invalid={isInvalid}
+			errorText={isInvalid ? meta.error : undefined}
+			label={<VisuallyHidden>{props.name}</VisuallyHidden>}
+		>
 			<Input
 				placeholder={props.name}
-				bg={useColorModeValue("gray.100", "gray.300")}
+				bg={bg}
 				border={0}
 				color={"gray.700"}
 				_placeholder={{
@@ -35,8 +31,7 @@ const InputField = (props: Props) => {
 				{...field}
 				{...props}
 			/>
-			{isInvalid && <FormErrorMessage>{meta.error}</FormErrorMessage>}
-		</FormControl>
+		</Field>
 	);
 };
 

--- a/client-app/src/components/forms/InputDate.tsx
+++ b/client-app/src/components/forms/InputDate.tsx
@@ -1,31 +1,31 @@
-import {
-	FormControl,
-	FormErrorMessage,
-	FormLabel,
-	Input,
-	useColorModeValue,
-	VisuallyHidden,
-} from "@chakra-ui/react";
+import { Input, VisuallyHidden } from "@chakra-ui/react";
 import { useField } from "formik";
-import DatePicker, { ReactDatePickerProps } from "react-datepicker";
+import DatePicker from "react-datepicker";
+import { Field } from "../ui/field";
+import { useColorModeValue } from "../ui/color-mode";
 
-type Props = Partial<ReactDatePickerProps> & {
+type Props = {
 	name: string;
+	[k: string]: unknown;
 };
 
 const InputDate = ({ name, ...rest }: Props) => {
 	const [field, meta, helpers] = useField(name);
 	const isInvalid = Boolean(meta.touched && meta.error);
+	const bg = useColorModeValue("gray.100", "gray.300");
 
 	return (
-		<FormControl id={name} isInvalid={isInvalid}>
-			<VisuallyHidden>
-				<FormLabel>{name}</FormLabel>
-			</VisuallyHidden>
+		<Field
+			id={name}
+			invalid={isInvalid}
+			errorText={isInvalid ? meta.error : undefined}
+			label={<VisuallyHidden>{name}</VisuallyHidden>}
+		>
 			<DatePicker
+				{...rest}
 				customInput={
 					<Input
-						bgColor={useColorModeValue("gray.100", "gray.300")}
+						bgColor={bg}
 						border={0}
 						color={"gray.700"}
 						_placeholder={{
@@ -35,14 +35,13 @@ const InputDate = ({ name, ...rest }: Props) => {
 					/>
 				}
 				placeholderText={name}
-				{...field}
-				{...rest}
-				selected={(field.value && new Date(field.value)) || null}
-				onChange={(v) => helpers.setValue(v)}
+				name={field.name}
+				selected={field.value ? new Date(field.value) : null}
+				onChange={(v: Date | null) => {
+					helpers.setValue(v);
+				}}
 			/>
-
-			{isInvalid && <FormErrorMessage>{meta.error}</FormErrorMessage>}
-		</FormControl>
+		</Field>
 	);
 };
 

--- a/client-app/src/components/forms/InputSelect.tsx
+++ b/client-app/src/components/forms/InputSelect.tsx
@@ -1,16 +1,13 @@
 import {
-	FormControl,
+	NativeSelect,
+	type NativeSelectFieldProps,
 	VisuallyHidden,
-	FormLabel,
-	Select,
-	FormErrorMessage,
-	SelectProps,
-	useColorModeValue,
 } from "@chakra-ui/react";
 import { useField } from "formik";
-import React from "react";
+import { Field } from "../ui/field";
+import { useColorModeValue } from "../ui/color-mode";
 
-type Props = SelectProps & {
+type Props = NativeSelectFieldProps & {
 	name: string;
 	options: { label: string; value: string | number }[];
 	[k: string]: unknown;
@@ -19,28 +16,32 @@ type Props = SelectProps & {
 const InputSelect = ({ name, options, ...rest }: Props) => {
 	const [field, meta] = useField(name);
 	const isInvalid = Boolean(meta.touched && meta.error);
+	const bg = useColorModeValue("gray.100", "gray.300");
 
 	return (
-		<FormControl id={name} isInvalid={isInvalid}>
-			<VisuallyHidden>
-				<FormLabel>{name}</FormLabel>
-			</VisuallyHidden>
-			<Select
-				bgColor={useColorModeValue("gray.100", "gray.300")}
-				color={"black"}
-				placeholder={`Select a ${name}`}
-				{...rest}
-				{...field}
-			>
-				{options?.map(({ label, value }) => (
-					<option key={label} value={value}>
-						{label}
-					</option>
-				))}
-			</Select>
-
-			{isInvalid && <FormErrorMessage>{meta.error}</FormErrorMessage>}
-		</FormControl>
+		<Field
+			id={name}
+			invalid={isInvalid}
+			errorText={isInvalid ? meta.error : undefined}
+			label={<VisuallyHidden>{name}</VisuallyHidden>}
+		>
+			<NativeSelect.Root>
+				<NativeSelect.Field
+					bgColor={bg}
+					color={"black"}
+					placeholder={`Select a ${name}`}
+					{...rest}
+					{...field}
+				>
+					{options?.map(({ label, value }) => (
+						<option key={label} value={value}>
+							{label}
+						</option>
+					))}
+				</NativeSelect.Field>
+				<NativeSelect.Indicator />
+			</NativeSelect.Root>
+		</Field>
 	);
 };
 

--- a/client-app/src/components/forms/InputTextArea.tsx
+++ b/client-app/src/components/forms/InputTextArea.tsx
@@ -1,14 +1,7 @@
-import {
-	FormControl,
-	VisuallyHidden,
-	FormLabel,
-	Textarea,
-	FormErrorMessage,
-	TextareaProps,
-	useColorModeValue,
-} from "@chakra-ui/react";
+import { Textarea, type TextareaProps, VisuallyHidden } from "@chakra-ui/react";
 import { useField } from "formik";
-import React from "react";
+import { Field } from "../ui/field";
+import { useColorModeValue } from "../ui/color-mode";
 
 type Props = TextareaProps & {
 	name: string;
@@ -17,15 +10,18 @@ type Props = TextareaProps & {
 const InputTextArea = ({ name, ...rest }: Props) => {
 	const [field, meta] = useField(name);
 	const isInvalid = Boolean(meta.touched && meta.error);
+	const bg = useColorModeValue("gray.100", "gray.300");
 
 	return (
-		<FormControl id={name} isInvalid={isInvalid}>
-			<VisuallyHidden>
-				<FormLabel>{name}</FormLabel>
-			</VisuallyHidden>
+		<Field
+			id={name}
+			invalid={isInvalid}
+			errorText={isInvalid ? meta.error : undefined}
+			label={<VisuallyHidden>{name}</VisuallyHidden>}
+		>
 			<Textarea
 				placeholder={name}
-				bgColor={useColorModeValue("gray.100", "gray.300")}
+				bgColor={bg}
 				border={0}
 				color={"gray.700"}
 				resize="vertical"
@@ -36,9 +32,7 @@ const InputTextArea = ({ name, ...rest }: Props) => {
 				{...field}
 				{...rest}
 			/>
-
-			{isInvalid && <FormErrorMessage>{meta.error}</FormErrorMessage>}
-		</FormControl>
+		</Field>
 	);
 };
 

--- a/client-app/src/components/imageUpload/PhotoUploadWidget.tsx
+++ b/client-app/src/components/imageUpload/PhotoUploadWidget.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, ButtonGroup, Flex, HStack, Text, VStack } from "@chakra-ui/react";
+import { Box, Button, Group, Flex, HStack, Text, VStack } from "@chakra-ui/react";
 import { observer } from "mobx-react-lite";
 import { useEffect, useState } from "react";
 import PhotoWidgetCropper from "./PhotoWidgetCropper";
@@ -30,7 +30,7 @@ const PhotoUploadWidget = ({ handlePhotoUpload, isUploading }: Props) => {
 	}, [files]);
 
 	return (
-		<VStack spacing={6} w="full">
+		<VStack gap={6} w="full">
 			<Flex justifyContent="space-between" w="full" px={6}>
 				<Text fontSize="xl">Step 1: Add Photo</Text>
 				<Text fontSize="xl">Step 2: Resize Image</Text>
@@ -49,14 +49,14 @@ const PhotoUploadWidget = ({ handlePhotoUpload, isUploading }: Props) => {
 					{files && files.length > 0 && (
 						<Flex flexDir="column" alignItems="center" w="full">
 							<Box className="img-preview" minH={200} w="full" overflow="hidden" />
-							<ButtonGroup size="lg" isAttached variant="solid" mt={6}>
-								<Button colorScheme="blue" isLoading={isUploading} onClick={onCrop}>
+							<Group attached mt={6}>
+								<Button size="lg" variant="solid" colorPalette="blue" loading={isUploading} onClick={onCrop}>
 									Save
 								</Button>
-								<Button colorScheme="red" isDisabled={isUploading} onClick={() => setFiles([])}>
+								<Button size="lg" variant="solid" colorPalette="red" disabled={isUploading} onClick={() => setFiles([])}>
 									Close
 								</Button>
-							</ButtonGroup>
+							</Group>
 						</Flex>
 					)}
 				</Flex>

--- a/client-app/src/components/ui/avatar.tsx
+++ b/client-app/src/components/ui/avatar.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Avatar as ChakraAvatar } from "@chakra-ui/react";
+import * as React from "react";
+
+type ImageProps = React.ImgHTMLAttributes<HTMLImageElement>;
+
+export interface AvatarProps extends ChakraAvatar.RootProps {
+	name?: string;
+	src?: string;
+	srcSet?: string;
+	loading?: ImageProps["loading"];
+	icon?: React.ReactElement;
+	fallback?: React.ReactNode;
+}
+
+export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
+	function Avatar(props, ref) {
+		const { name, src, srcSet, loading, icon, fallback, children, ...rest } =
+			props;
+		return (
+			<ChakraAvatar.Root ref={ref} {...rest}>
+				<ChakraAvatar.Fallback name={name}>
+					{icon}
+					{fallback}
+				</ChakraAvatar.Fallback>
+				<ChakraAvatar.Image src={src} srcSet={srcSet} loading={loading} />
+				{children}
+			</ChakraAvatar.Root>
+		);
+	},
+);
+

--- a/client-app/src/components/ui/color-mode.tsx
+++ b/client-app/src/components/ui/color-mode.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { IconButton, type IconButtonProps, Span } from "@chakra-ui/react";
+import { MoonIcon, SunIcon } from "@heroicons/react/24/outline";
+import * as React from "react";
+
+export type ColorMode = "light" | "dark";
+
+interface ColorModeContextValue {
+	colorMode: ColorMode;
+	setColorMode: (mode: ColorMode) => void;
+	toggleColorMode: () => void;
+}
+
+const ColorModeContext = React.createContext<ColorModeContextValue>({
+	colorMode: "light",
+	setColorMode: () => {},
+	toggleColorMode: () => {},
+});
+
+const STORAGE_KEY = "chakra-ui-color-mode";
+
+function applyColorMode(mode: ColorMode) {
+	if (typeof document === "undefined") return;
+	const root = document.documentElement;
+	root.classList.remove("light", "dark");
+	root.classList.add(mode);
+	root.style.colorScheme = mode;
+}
+
+export interface ColorModeProviderProps {
+	children: React.ReactNode;
+	defaultValue?: ColorMode;
+}
+
+export function ColorModeProvider(props: ColorModeProviderProps) {
+	const { children, defaultValue = "light" } = props;
+	const [colorMode, setColorModeState] = React.useState<ColorMode>(() => {
+		if (typeof window === "undefined") return defaultValue;
+		const stored = window.localStorage.getItem(STORAGE_KEY);
+		return stored === "dark" || stored === "light" ? stored : defaultValue;
+	});
+
+	const setColorMode = React.useCallback((mode: ColorMode) => {
+		setColorModeState(mode);
+		if (typeof window !== "undefined") {
+			window.localStorage.setItem(STORAGE_KEY, mode);
+		}
+		applyColorMode(mode);
+	}, []);
+
+	const toggleColorMode = React.useCallback(() => {
+		setColorMode(colorMode === "dark" ? "light" : "dark");
+	}, [colorMode, setColorMode]);
+
+	React.useEffect(() => {
+		applyColorMode(colorMode);
+	}, [colorMode]);
+
+	const value = React.useMemo(
+		() => ({ colorMode, setColorMode, toggleColorMode }),
+		[colorMode, setColorMode, toggleColorMode],
+	);
+
+	return (
+		<ColorModeContext.Provider value={value}>
+			{children}
+		</ColorModeContext.Provider>
+	);
+}
+
+export function useColorMode() {
+	const context = React.useContext(ColorModeContext);
+	if (context === undefined) {
+		throw new Error("useColorMode must be used within a ColorModeProvider");
+	}
+	return context;
+}
+
+export function useColorModeValue<T>(light: T, dark: T) {
+	const { colorMode } = useColorMode();
+	return colorMode === "dark" ? dark : light;
+}
+
+export function ColorModeIcon() {
+	const { colorMode } = useColorMode();
+	return colorMode === "dark" ? (
+		<MoonIcon width={20} height={20} />
+	) : (
+		<SunIcon width={20} height={20} />
+	);
+}
+
+interface ColorModeButtonProps extends Omit<IconButtonProps, "aria-label"> {}
+
+export const ColorModeButton = React.forwardRef<
+	HTMLButtonElement,
+	ColorModeButtonProps
+>(function ColorModeButton(props, ref) {
+	const { toggleColorMode } = useColorMode();
+	return (
+		<IconButton
+			onClick={toggleColorMode}
+			variant="ghost"
+			aria-label="Toggle color mode"
+			size="sm"
+			ref={ref}
+			{...props}
+			css={{
+				_icon: {
+					width: "5",
+					height: "5",
+				},
+			}}
+		>
+			<ColorModeIcon />
+		</IconButton>
+	);
+});
+
+export function LightMode(props: React.ComponentProps<typeof Span>) {
+	return (
+		<Span
+			color="fg"
+			display="contents"
+			className="chakra-theme light"
+			colorPalette="gray"
+			colorScheme="light"
+			{...props}
+		/>
+	);
+}
+
+export function DarkMode(props: React.ComponentProps<typeof Span>) {
+	return (
+		<Span
+			color="fg"
+			display="contents"
+			className="chakra-theme dark"
+			colorPalette="gray"
+			colorScheme="dark"
+			{...props}
+		/>
+	);
+}

--- a/client-app/src/components/ui/field.tsx
+++ b/client-app/src/components/ui/field.tsx
@@ -1,0 +1,33 @@
+import { Field as ChakraField } from "@chakra-ui/react";
+import * as React from "react";
+
+export interface FieldProps extends Omit<ChakraField.RootProps, "label"> {
+	label?: React.ReactNode;
+	helperText?: React.ReactNode;
+	errorText?: React.ReactNode;
+	optionalText?: React.ReactNode;
+}
+
+export const Field = React.forwardRef<HTMLDivElement, FieldProps>(
+	function Field(props, ref) {
+		const { label, children, helperText, errorText, optionalText, ...rest } =
+			props;
+		return (
+			<ChakraField.Root ref={ref} {...rest}>
+				{label && (
+					<ChakraField.Label>
+						{label}
+						<ChakraField.RequiredIndicator fallback={optionalText} />
+					</ChakraField.Label>
+				)}
+				{children}
+				{helperText && (
+					<ChakraField.HelperText>{helperText}</ChakraField.HelperText>
+				)}
+				{errorText && (
+					<ChakraField.ErrorText>{errorText}</ChakraField.ErrorText>
+				)}
+			</ChakraField.Root>
+		);
+	},
+);

--- a/client-app/src/components/ui/provider.tsx
+++ b/client-app/src/components/ui/provider.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { ColorModeProvider, type ColorModeProviderProps } from "./color-mode";
+
+export function Provider(props: ColorModeProviderProps) {
+	return (
+		<ChakraProvider value={defaultSystem}>
+			<ColorModeProvider {...props} />
+		</ChakraProvider>
+	);
+}

--- a/client-app/src/components/ui/toaster.tsx
+++ b/client-app/src/components/ui/toaster.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import {
+	Toaster as ChakraToaster,
+	Portal,
+	Spinner,
+	Stack,
+	Toast,
+	createToaster,
+} from "@chakra-ui/react";
+
+export const toaster = createToaster({
+	placement: "bottom-end",
+	pauseOnPageIdle: true,
+});
+
+export function Toaster() {
+	return (
+		<Portal>
+			<ChakraToaster toaster={toaster} insetInline={{ mdDown: "4" }}>
+				{(toast) => (
+					<Toast.Root width={{ md: "sm" }}>
+						{toast.type === "loading" ? (
+							<Spinner size="sm" color="blue.solid" />
+						) : (
+							<Toast.Indicator />
+						)}
+						<Stack gap="1" flex="1" maxWidth="100%">
+							{toast.title && <Toast.Title>{toast.title}</Toast.Title>}
+							{toast.description && (
+								<Toast.Description>{toast.description}</Toast.Description>
+							)}
+						</Stack>
+						{toast.action && (
+							<Toast.ActionTrigger>{toast.action.label}</Toast.ActionTrigger>
+						)}
+						{toast.closable && <Toast.CloseTrigger />}
+					</Toast.Root>
+				)}
+			</ChakraToaster>
+		</Portal>
+	);
+}

--- a/client-app/src/features/activities/dashboard/ActivityDashboard.tsx
+++ b/client-app/src/features/activities/dashboard/ActivityDashboard.tsx
@@ -40,7 +40,7 @@ const ActivityDashboard = () => {
 				columns={{
 					md: 3,
 				}}
-				spacing={{
+				gap={{
 					md: 6,
 				}}
 				pt={12}

--- a/client-app/src/features/activities/dashboard/ActivityFilters.tsx
+++ b/client-app/src/features/activities/dashboard/ActivityFilters.tsx
@@ -1,18 +1,20 @@
-import { Flex, Heading, ListItem, UnorderedList, useColorModeValue } from "@chakra-ui/react";
+import { Flex, Heading, List } from "@chakra-ui/react";
 import { observer } from "mobx-react-lite";
 import Calendar from "react-calendar";
 import { useStoreContext } from "~/stores/store";
+import { useColorModeValue } from "../../../components/ui/color-mode";
 
 const ActivityFilters = () => {
 	const {
 		activityStore: { predicate, setPredicate },
 	} = useStoreContext();
+	const bg = useColorModeValue("white", "gray.700");
 	return (
 		<>
 			<Flex
 				flexDir="column"
 				py={4}
-				bg={useColorModeValue("white", "gray.700")}
+				bg={bg}
 				boxShadow={"sm"}
 				mb={8}
 				mt={[0, 0, 16]}
@@ -36,7 +38,7 @@ const ActivityFilters = () => {
 				>
 					Filters
 				</Heading>
-				<UnorderedList listStyleType="none" m={0}>
+				<List.Root listStyleType="none" m={0}>
 					<ListItemWrapper
 						onClick={() => setPredicate("all", "true")}
 						active={predicate.has("all")}
@@ -55,10 +57,10 @@ const ActivityFilters = () => {
 					>
 						I&apos;m hosting
 					</ListItemWrapper>
-				</UnorderedList>
+				</List.Root>
 			</Flex>
 			<Calendar
-				onChange={(date: Date) => setPredicate("startDate", date as Date)}
+				onChange={(value) => setPredicate("startDate", value as Date)}
 				value={predicate.get("startDate") || new Date()}
 			/>
 		</>
@@ -76,7 +78,7 @@ const ListItemWrapper = ({
 }) => {
 	const bgc = useColorModeValue("gray.200", "gray.600");
 	return (
-		<ListItem
+		<List.Item
 			display="flex"
 			borderBottom="1px solid"
 			borderColor="gray.300"
@@ -91,7 +93,7 @@ const ListItemWrapper = ({
 			backgroundColor={active ? bgc : ""}
 		>
 			{children}
-		</ListItem>
+		</List.Item>
 	);
 };
 

--- a/client-app/src/features/activities/dashboard/ActivityList.tsx
+++ b/client-app/src/features/activities/dashboard/ActivityList.tsx
@@ -10,11 +10,11 @@ const ActivityList = () => {
 
 	return (
 		<>
-			<Stack spacing={8} mx={"auto"}>
+			<Stack gap={8} mx={"auto"}>
 				{groupedActivities.map(([group, list]) => (
 					<Fragment key={group}>
 						<Heading fontSize="2xl">{group}</Heading>
-						<Stack spacing={8} mx={"auto"}>
+						<Stack gap={8} mx={"auto"}>
 							{list?.map((act) => (
 								<ActivityListItem activity={act} key={act.id} />
 							))}

--- a/client-app/src/features/activities/dashboard/ActivityListItem.tsx
+++ b/client-app/src/features/activities/dashboard/ActivityListItem.tsx
@@ -1,5 +1,4 @@
 import {
-	Avatar,
 	Badge,
 	Box,
 	Button,
@@ -8,8 +7,9 @@ import {
 	HStack,
 	Image,
 	Text,
-	useColorModeValue,
 } from "@chakra-ui/react";
+import { Avatar } from "../../../components/ui/avatar";
+import { useColorModeValue } from "../../../components/ui/color-mode";
 import { MapPinIcon } from "@heroicons/react/24/solid";
 import { observer } from "mobx-react-lite";
 import { Link } from "react-router-dom";
@@ -43,11 +43,11 @@ const ActivityListItem = ({ activity }: Props) => {
 							Event
 						</Text>
 						<HStack pt={1}>
-							{activity.isCancelled && <Badge colorScheme="red">Activity Cancelled</Badge>}
-							{activity.isHost && <Badge colorScheme="purple">Hosting</Badge>}
-							{activity.isGoing && !activity.isHost && <Badge colorScheme="green">Attending</Badge>}
+							{activity.isCancelled && <Badge colorPalette="red">Activity Cancelled</Badge>}
+							{activity.isHost && <Badge colorPalette="purple">Hosting</Badge>}
+							{activity.isGoing && !activity.isHost && <Badge colorPalette="green">Attending</Badge>}
 							{!activity.isGoing && !activity.isHost && (
-								<Badge colorScheme="yellow">Not Attending</Badge>
+								<Badge colorPalette="yellow">Not Attending</Badge>
 							)}
 						</HStack>
 					</Flex>
@@ -63,8 +63,7 @@ const ActivityListItem = ({ activity }: Props) => {
 					<CalendarDate date={date!} />
 					<Flex flexDir="column" w="full">
 						<Heading
-							as={Link}
-							to={`${id}`}
+							asChild
 							_hover={{
 								textDecoration: "underline",
 							}}
@@ -73,7 +72,7 @@ const ActivityListItem = ({ activity }: Props) => {
 							mb={1}
 							textTransform="capitalize"
 						>
-							{title}
+							<Link to={`${id}`}>{title}</Link>
 						</Heading>
 						<Flex flexDir="row" alignItems="center">
 							<MapPinIcon width={16} height={16} />
@@ -83,8 +82,8 @@ const ActivityListItem = ({ activity }: Props) => {
 						</Flex>
 					</Flex>
 				</Flex>
-				<Button colorScheme="teal" as={Link} to={`${id}`}>
-					View
+				<Button colorPalette="teal" asChild>
+					<Link to={`${id}`}>View</Link>
 				</Button>
 			</Flex>
 			{attendees && (

--- a/client-app/src/features/activities/dashboard/ListItemAttendee.tsx
+++ b/client-app/src/features/activities/dashboard/ListItemAttendee.tsx
@@ -1,14 +1,8 @@
-import {
-	Avatar,
-	HStack,
-	Popover,
-	PopoverContent,
-	PopoverTrigger,
-	useDisclosure,
-} from "@chakra-ui/react";
+import { HStack, Popover, Portal, useDisclosure } from "@chakra-ui/react";
 import { Link } from "react-router-dom";
 import ProfileCard from "~/features/profiles/ProfileCard";
 import { Profile } from "~/types";
+import { Avatar } from "../../../components/ui/avatar";
 
 type Props = {
 	attendees?: Profile[];
@@ -24,18 +18,17 @@ const ListItemAttendee = ({ attendees }: Props) => {
 };
 
 const AttendeePopover = ({ profile }: { profile: Profile }) => {
-	const { isOpen, onClose, onOpen } = useDisclosure();
+	const { open, onClose, onOpen } = useDisclosure();
 	return (
-		<Popover
+		<Popover.Root
 			key={profile.username}
-			isLazy
-			returnFocusOnClose={false}
-			isOpen={isOpen}
-			onClose={onClose}
-			placement="top-start"
-			closeOnBlur={false}
+			lazyMount
+			open={open}
+			onOpenChange={(e) => (e.open ? onOpen() : onClose())}
+			positioning={{ placement: "top-start" }}
+			closeOnInteractOutside={false}
 		>
-			<PopoverTrigger>
+			<Popover.Trigger asChild>
 				<Link to={`/profiles/${profile.username}`} onMouseEnter={onOpen} onMouseLeave={onClose}>
 					<Avatar
 						border="2px solid var(--chakra-colors-gray-100)"
@@ -49,13 +42,17 @@ const AttendeePopover = ({ profile }: { profile: Profile }) => {
 						name={profile.displayName}
 					/>
 				</Link>
-			</PopoverTrigger>
-			<PopoverContent id="content">
-				<>
-					<ProfileCard profile={profile} />
-				</>
-			</PopoverContent>
-		</Popover>
+			</Popover.Trigger>
+			<Portal>
+				<Popover.Positioner>
+					<Popover.Content id="content">
+						<Popover.Body p={0}>
+							<ProfileCard profile={profile} />
+						</Popover.Body>
+					</Popover.Content>
+				</Popover.Positioner>
+			</Portal>
+		</Popover.Root>
 	);
 };
 

--- a/client-app/src/features/activities/dashboard/ListItemSkeleton.tsx
+++ b/client-app/src/features/activities/dashboard/ListItemSkeleton.tsx
@@ -4,8 +4,8 @@ import {
 	Skeleton,
 	SkeletonCircle,
 	SkeletonText,
-	useColorModeValue,
 } from "@chakra-ui/react";
+import { useColorModeValue } from "../../../components/ui/color-mode";
 import React from "react";
 
 const ListItemSkeleton = () => {
@@ -18,7 +18,7 @@ const ListItemSkeleton = () => {
 				<SkeletonText noOfLines={1} />
 			</HStack>
 			<Skeleton height="320px" />
-			<SkeletonText mt="4" noOfLines={4} spacing={6} />
+			<SkeletonText mt="4" noOfLines={4} gap={6} />
 		</Box>
 	);
 };

--- a/client-app/src/features/activities/details/ActivityDetailedChat.tsx
+++ b/client-app/src/features/activities/details/ActivityDetailedChat.tsx
@@ -1,5 +1,4 @@
 import {
-	Avatar,
 	Box,
 	Button,
 	Flex,
@@ -7,13 +6,15 @@ import {
 	HStack,
 	Link,
 	Text,
-	useColorModeValue,
 } from "@chakra-ui/react";
+import { Avatar } from "../../../components/ui/avatar";
+import { useColorModeValue } from "../../../components/ui/color-mode";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { Form, Formik, FormikProps } from "formik";
 import { observer } from "mobx-react-lite";
 import { useEffect } from "react";
+import { Link as RouterLink } from "react-router-dom";
 import * as yup from "yup";
 import InputTextArea from "~/components/forms/InputTextArea";
 import { useStoreContext } from "~/stores/store";
@@ -69,7 +70,7 @@ const ActivityDetailedChat = ({ activityId }: Props) => {
 				{!userStore.isLoggedIn ? (
 					<Text mb={8}>
 						You must be{" "}
-						<Link textColor="blue.500" fontWeight={500}>
+						<Link color="blue.500" fontWeight={500}>
 							logged in
 						</Link>{" "}
 						to post a comment.
@@ -102,9 +103,9 @@ const ActivityDetailedChat = ({ activityId }: Props) => {
 										/>
 										<Button
 											type="submit"
-											isDisabled={!dirty || !isValid}
-											isLoading={isSubmitting}
-											colorScheme="teal"
+											disabled={!dirty || !isValid}
+											loading={isSubmitting}
+											colorPalette="teal"
 											size="md"
 										>
 											Add Reply
@@ -124,10 +125,10 @@ const ActivityDetailedChat = ({ activityId }: Props) => {
 								<Avatar src={comm?.image ?? "/assets/user.png"} name={comm?.displayName} />
 								<Flex flexDir="column" ml={4}>
 									<Flex alignItems="center">
-										<Text as={Link} to={`/profiles/${comm.username}`} fontWeight={700}>
-											{comm?.displayName}
+										<Text asChild fontWeight={700}>
+											<RouterLink to={`/profiles/${comm.username}`}>{comm?.displayName}</RouterLink>
 										</Text>
-										<Text ml={2} fontSize="xs" textColor="gray.500">
+										<Text ml={2} fontSize="xs" color="gray.500">
 											{dayjs(comm.createdAt).fromNow()}
 										</Text>
 									</Flex>

--- a/client-app/src/features/activities/details/ActivityDetailedHeader.tsx
+++ b/client-app/src/features/activities/details/ActivityDetailedHeader.tsx
@@ -3,12 +3,13 @@ import {
 	Box,
 	Button,
 	Container,
+	Fieldset,
 	Flex,
 	Heading,
 	Text,
-	useColorModeValue,
 	VStack,
 } from "@chakra-ui/react";
+import { useColorModeValue } from "../../../components/ui/color-mode";
 import { ClockIcon, MapPinIcon, TagIcon } from "@heroicons/react/24/solid";
 import dayjs from "dayjs";
 import { observer } from "mobx-react-lite";
@@ -49,7 +50,7 @@ const ActivityDetailedHeader = ({ activity }: Props) => {
 									{activity.title}
 								</Heading>
 								{activity.isCancelled && (
-									<Badge ml={4} mt={-2} display="flex" colorScheme="red" fontSize="lg">
+									<Badge ml={4} mt={-2} display="flex" colorPalette="red" fontSize="lg">
 										Activity is Cancelled
 									</Badge>
 								)}
@@ -76,15 +77,15 @@ const ActivityDetailedHeader = ({ activity }: Props) => {
 							</Flex>
 						</Flex>
 					</Flex>
-					<VStack as="fieldset" disabled={isLoading}>
+					<Fieldset.Root as={VStack} disabled={isLoading}>
 						{!activity?.isHost && activity?.isGoing && (
-							<Button w="full" colorScheme="yellow" size="lg" onClick={updateAttendance}>
+							<Button w="full" colorPalette="yellow" size="lg" onClick={updateAttendance}>
 								Cancel Attendance
 							</Button>
 						)}
 						{!activity?.isHost && !activity?.isGoing && (
 							<Button
-								colorScheme="teal"
+								colorPalette="teal"
 								size="lg"
 								onClick={updateAttendance}
 								disabled={activity.isCancelled}
@@ -95,25 +96,26 @@ const ActivityDetailedHeader = ({ activity }: Props) => {
 						{activity?.isHost && (
 							<>
 								<Button
-									colorScheme={activity.isCancelled ? "green" : "red"}
+									colorPalette={activity.isCancelled ? "green" : "red"}
 									onClick={cancelActivityToggle}
-									isLoading={isLoading}
+									loading={isLoading}
 								>
 									{activity.isCancelled ? "Re-activate Activity" : "Cancel Activity"}
 								</Button>
 								<Button
-									as={Link}
+									asChild
 									disabled={activity.isCancelled}
-									to={`/activities/${activity.id}/manage`}
 									w="full"
-									colorScheme="orange"
+									colorPalette="orange"
 									size="md"
 								>
-									Manage Event
+									<Link to={`/activities/${activity.id}/manage`}>
+										Manage Event
+									</Link>
 								</Button>
 							</>
 						)}
-					</VStack>
+					</Fieldset.Root>
 				</Flex>
 			</Container>
 		</Flex>

--- a/client-app/src/features/activities/details/ActivityDetailedInfo.tsx
+++ b/client-app/src/features/activities/details/ActivityDetailedInfo.tsx
@@ -1,4 +1,9 @@
-import { Flex, Heading, Text, useColorModeValue } from "@chakra-ui/react";
+import {
+	Flex,
+	Heading,
+	Text,
+} from "@chakra-ui/react";
+import { useColorModeValue } from "../../../components/ui/color-mode";
 import { observer } from "mobx-react-lite";
 import React from "react";
 import { Activity } from "~/types";

--- a/client-app/src/features/activities/details/ActivityDetailedSideBar.tsx
+++ b/client-app/src/features/activities/details/ActivityDetailedSideBar.tsx
@@ -1,6 +1,12 @@
-import { Flex, Heading, Text, UnorderedList, useColorModeValue } from "@chakra-ui/react";
+import {
+	Flex,
+	Heading,
+	List,
+	Text,
+} from "@chakra-ui/react";
 import { observer } from "mobx-react-lite";
 import { Activity } from "~/types";
+import { useColorModeValue } from "../../../components/ui/color-mode";
 import { AttendeeListItem } from "./Sidebar.helper";
 
 type Props = {
@@ -9,8 +15,9 @@ type Props = {
 
 const ActivityDetailedSideBar = ({ activity }: Props) => {
 	const { attendees, hostUsername } = activity;
+	const bg = useColorModeValue("white", "gray.700");
 	return (
-		<Flex flexDir="column" p={4} bg={useColorModeValue("white", "gray.700")} boxShadow={"sm"}>
+		<Flex flexDir="column" p={4} bg={bg} boxShadow={"sm"}>
 			<Flex mb={8} alignItems="center">
 				<Heading
 					as="h4"
@@ -33,7 +40,7 @@ const ActivityDetailedSideBar = ({ activity }: Props) => {
 					({attendees?.length || 0}) {attendees?.length === 1 ? "Person" : "People"} going
 				</Text>
 			</Flex>
-			<UnorderedList listStyleType="none">
+			<List.Root listStyleType="none">
 				{attendees?.map((attendee) => (
 					<AttendeeListItem
 						key={attendee.username}
@@ -41,7 +48,7 @@ const ActivityDetailedSideBar = ({ activity }: Props) => {
 						hostUsername={hostUsername}
 					/>
 				))}
-			</UnorderedList>
+			</List.Root>
 		</Flex>
 	);
 };

--- a/client-app/src/features/activities/details/Sidebar.helper.tsx
+++ b/client-app/src/features/activities/details/Sidebar.helper.tsx
@@ -1,4 +1,10 @@
-import { ListItem, Avatar, Flex, Badge, Text } from "@chakra-ui/react";
+import {
+	List,
+	Flex,
+	Badge,
+	Text,
+} from "@chakra-ui/react";
+import { Avatar } from "../../../components/ui/avatar";
 import { observer } from "mobx-react-lite";
 import React from "react";
 import { Link } from "react-router-dom";
@@ -6,7 +12,7 @@ import { Profile } from "~/types";
 
 export const AttendeeListItem = observer(
 	({ attendee, hostUsername }: { attendee: Profile; hostUsername?: string }) => (
-		<ListItem
+		<List.Item
 			key={attendee.username}
 			display="flex"
 			justifyContent="center"
@@ -30,17 +36,17 @@ export const AttendeeListItem = observer(
 						</Text>
 					</Link>
 					{hostUsername && hostUsername === attendee.username && (
-						<Badge variant="subtle" colorScheme="green">
+						<Badge variant="subtle" colorPalette="green">
 							Host
 						</Badge>
 					)}
 				</Flex>
 				{attendee.following && (
-					<Text mt={-1} fontSize="sm" fontWeight={500} letterSpacing="wide" textColor="orange">
+					<Text mt={-1} fontSize="sm" fontWeight={500} letterSpacing="wide" color="orange">
 						Following
 					</Text>
 				)}
 			</Flex>
-		</ListItem>
+		</List.Item>
 	),
 );

--- a/client-app/src/features/activities/form/ActivityForm.tsx
+++ b/client-app/src/features/activities/form/ActivityForm.tsx
@@ -1,4 +1,11 @@
-import { Box, Button, Flex, Heading, Stack, useColorModeValue } from "@chakra-ui/react";
+import {
+	Box,
+	Button,
+	Flex,
+	Heading,
+	Stack,
+} from "@chakra-ui/react";
+import { useColorModeValue } from "../../../components/ui/color-mode";
 import { Form, Formik, FormikProps } from "formik";
 import { observer } from "mobx-react-lite";
 import { useEffect, useMemo, useState } from "react";
@@ -67,7 +74,7 @@ const ActivityForm = () => {
 				{({ isSubmitting, dirty, isValid }: FormikProps<ActivityFormValues>) => (
 					<Form>
 						<Flex p={8} flex={1} align={"center"} justify={"center"}>
-							<Stack spacing={4} w={"full"} maxW={"md"}>
+							<Stack gap={4} w={"full"} maxW={"md"}>
 								<Heading fontSize={"2xl"}>{isEditing ? "Edit" : "Create"} an Activity</Heading>
 								<InputField name="title" />
 								<InputTextArea name="description" />
@@ -80,21 +87,28 @@ const ActivityForm = () => {
 								/>
 								<InputField name="city" />
 								<InputField name="venue" />
-								<Stack direction={"row"} justifyContent="center" spacing={6}>
+								<Stack direction={"row"} justifyContent="center" gap={6}>
 									<Button
-										as={Link}
-										to={isEditing ? `/activities/${activity?.id}` : "/activities"}
-										isLoading={isLoadingInitial || isSubmitting}
-										colorScheme={"gray"}
+										asChild
+										loading={isLoadingInitial || isSubmitting}
+										colorPalette={"gray"}
 										variant={"solid"}
 									>
-										Cancel
+										<Link
+											to={
+												isEditing
+													? `/activities/${activity?.id}`
+													: "/activities"
+											}
+										>
+											Cancel
+										</Link>
 									</Button>
 									<Button
-										isLoading={isLoadingInitial || isSubmitting}
+										loading={isLoadingInitial || isSubmitting}
 										disabled={isSubmitting || !dirty || !isValid}
 										type="submit"
-										colorScheme={"blue"}
+										colorPalette={"blue"}
 										variant={"solid"}
 									>
 										{isEditing ? "Edit" : "Submit"}

--- a/client-app/src/features/errors/NotFound.tsx
+++ b/client-app/src/features/errors/NotFound.tsx
@@ -21,14 +21,13 @@ const NotFound = () => {
 			</Text>
 
 			<Button
-				as={Link}
-				to="/activities"
-				colorScheme="teal"
+				asChild
+				colorPalette="teal"
 				bgGradient="linear(to-r, teal.400, teal.500, teal.600)"
 				color="white"
 				variant="solid"
 			>
-				Go to Home
+				<Link to="/activities">Go to Home</Link>
 			</Button>
 		</Box>
 	);

--- a/client-app/src/features/errors/ServerError.tsx
+++ b/client-app/src/features/errors/ServerError.tsx
@@ -13,13 +13,15 @@ const ServerError = () => {
 				{commonStore.error?.message}
 			</Heading>
 			{commonStore.error?.details && (
-				<Flex flexDir="column" as={Link} to="/activities">
-					<Heading as="h6" fontSize="2xl">
-						Stack Trace
-					</Heading>
-					<Flex as="code" mt={8}>
-						{commonStore.error?.details}
-					</Flex>
+				<Flex asChild flexDir="column">
+					<Link to="/activities">
+						<Heading as="h6" fontSize="2xl">
+							Stack Trace
+						</Heading>
+						<Flex as="code" mt={8}>
+							{commonStore.error?.details}
+						</Flex>
+					</Link>
 				</Flex>
 			)}
 		</Container>

--- a/client-app/src/features/errors/ValidationErrors.tsx
+++ b/client-app/src/features/errors/ValidationErrors.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Alert, AlertIcon, Stack } from "@chakra-ui/react";
-import React from "react";
+import { Alert, Stack } from "@chakra-ui/react";
 
 type Props = {
 	errors?: any;
@@ -11,10 +10,10 @@ const ValidationErrors = ({ errors }: Props) => {
 		<Stack mt={4}>
 			{errors &&
 				errors?.map((er: any, idx: any) => (
-					<Alert key={idx} status="error" variant="subtle">
-						<AlertIcon />
-						{er}
-					</Alert>
+					<Alert.Root key={idx} status="error" variant="subtle">
+						<Alert.Indicator />
+						<Alert.Content>{er}</Alert.Content>
+					</Alert.Root>
 				))}
 		</Stack>
 	);

--- a/client-app/src/features/home/HomePage.tsx
+++ b/client-app/src/features/home/HomePage.tsx
@@ -1,4 +1,4 @@
-import { Button, Divider, Flex, Heading, Stack } from "@chakra-ui/react";
+import { Button, Separator, Flex, Heading, Stack } from "@chakra-ui/react";
 import { observer } from "mobx-react-lite";
 import { Link } from "react-router-dom";
 import { useStoreContext } from "~/stores/store";
@@ -19,11 +19,11 @@ const HomePage = () => {
 					<Link to="/activities">Go to activities!</Link>
 				</>
 			) : (
-				<Stack spacing={6}>
+				<Stack gap={6}>
 					<LoginModal />
 					<RegisterModal />
-					<Divider />
-					<Button colorScheme="facebook" onClick={facebookLogin} isLoading={isLoadingFacebook}>
+					<Separator />
+					<Button colorPalette="facebook" onClick={facebookLogin} loading={isLoadingFacebook}>
 						Login with Facebook
 					</Button>
 				</Stack>

--- a/client-app/src/features/profiles/FollowButton.tsx
+++ b/client-app/src/features/profiles/FollowButton.tsx
@@ -20,12 +20,12 @@ const FollowButton = ({ profile, followProps, unfollowProps, stackProps }: Props
 		updateFollowing(username, !profile.following);
 	};
 	return (
-		<HStack spacing={4} w="full" {...stackProps}>
+		<HStack gap={4} w="full" {...stackProps}>
 			{profile?.following ? (
 				<Button
 					w="full"
-					colorScheme={"red"}
-					isLoading={isLoading}
+					colorPalette={"red"}
+					loading={isLoading}
 					onClick={(e) => handleFollow(e, profile.username)}
 					{...unfollowProps}
 				>
@@ -34,8 +34,8 @@ const FollowButton = ({ profile, followProps, unfollowProps, stackProps }: Props
 			) : (
 				<Button
 					w="full"
-					colorScheme={"green"}
-					isLoading={isLoading}
+					colorPalette={"green"}
+					loading={isLoading}
 					onClick={(e) => handleFollow(e, profile.username)}
 					{...followProps}
 				>

--- a/client-app/src/features/profiles/ProfileActivities.tsx
+++ b/client-app/src/features/profiles/ProfileActivities.tsx
@@ -1,24 +1,19 @@
 import {
-	Tabs,
-	TabList,
-	Tab,
-	TabPanels,
-	TabPanel,
 	Box,
-	Image,
-	VStack,
-	Heading,
 	Flex,
-	ListItem,
+	Heading,
+	Image,
 	List,
-	useColorModeValue,
+	Tabs,
+	VStack,
 } from "@chakra-ui/react";
 import dayjs from "dayjs";
 import { observer } from "mobx-react-lite";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useStoreContext } from "~/stores/store";
-import { UserActivity } from "~/types";
+import type { UserActivity } from "~/types";
+import { useColorModeValue } from "../../components/ui/color-mode";
 
 const panes = ["future", "past", "hosting"];
 
@@ -39,18 +34,32 @@ const ProfileActivities = () => {
 	}, [loadUserActivities, profile]);
 
 	return (
-		<Tabs index={tabIndex} onChange={handleTabsChange} isLazy>
-			<TabList>
-				<Tab isDisabled={isLoadingActivities}>Future Events</Tab>
-				<Tab isDisabled={isLoadingActivities}>Past Events</Tab>
-				<Tab isDisabled={isLoadingActivities}>Hosting</Tab>
-			</TabList>
-			<TabPanels>
-				<Panel key="FutureEvents" userActivities={userActivities} />
-				<Panel key="PastEvents" userActivities={userActivities} />
-				<Panel key="HostingEvents" userActivities={userActivities} />
-			</TabPanels>
-		</Tabs>
+		<Tabs.Root
+			value={String(tabIndex)}
+			onValueChange={(e) => handleTabsChange(Number(e.value))}
+			lazyMount
+		>
+			<Tabs.List>
+				<Tabs.Trigger value="0" disabled={isLoadingActivities}>
+					Future Events
+				</Tabs.Trigger>
+				<Tabs.Trigger value="1" disabled={isLoadingActivities}>
+					Past Events
+				</Tabs.Trigger>
+				<Tabs.Trigger value="2" disabled={isLoadingActivities}>
+					Hosting
+				</Tabs.Trigger>
+			</Tabs.List>
+			<Tabs.Content value="0">
+				<Panel userActivities={userActivities} />
+			</Tabs.Content>
+			<Tabs.Content value="1">
+				<Panel userActivities={userActivities} />
+			</Tabs.Content>
+			<Tabs.Content value="2">
+				<Panel userActivities={userActivities} />
+			</Tabs.Content>
+		</Tabs.Root>
 	);
 };
 
@@ -58,11 +67,11 @@ const Panel = ({ userActivities }: { userActivities: UserActivity[] }) => {
 	const cardBgColor = useColorModeValue("gray.200", "gray.600");
 
 	return (
-		<TabPanel>
-			<List display="flex" flexWrap="wrap" gap={4}>
+		<Box>
+			<List.Root display="flex" flexWrap="wrap" gap={4} listStyle="none">
 				{userActivities.map((activity) => {
 					return (
-						<ListItem
+						<List.Item
 							shadow="lg"
 							key={activity.id}
 							bgColor={cardBgColor}
@@ -71,12 +80,12 @@ const Panel = ({ userActivities }: { userActivities: UserActivity[] }) => {
 							overflow="hidden"
 						>
 							<Flex
-								as={Link}
-								to={`/activities/${activity.id}`}
+								asChild
 								flexDir="column"
 								alignItems="center"
 								justifyContent="center"
 							>
+								<Link to={`/activities/${activity.id}`}>
 								<Image
 									src={`/assets/categoryImages/${activity.category}.jpg`}
 									style={{ minHeight: 100, objectFit: "cover" }}
@@ -92,15 +101,14 @@ const Panel = ({ userActivities }: { userActivities: UserActivity[] }) => {
 										<div>{dayjs(activity.date).format("h:mm A")}</div>
 									</VStack>
 								</VStack>
+								</Link>
 							</Flex>
-						</ListItem>
+						</List.Item>
 					);
 				})}
-			</List>
-		</TabPanel>
+			</List.Root>
+		</Box>
 	);
 };
-
-// Panel.displayName = "UserActivitiesPanel";
 
 export default observer(ProfileActivities);

--- a/client-app/src/features/profiles/ProfileCard.tsx
+++ b/client-app/src/features/profiles/ProfileCard.tsx
@@ -1,4 +1,11 @@
-import { Avatar, Center, Flex, Heading, Text, useColorModeValue } from "@chakra-ui/react";
+import {
+	Center,
+	Flex,
+	Heading,
+	Text,
+} from "@chakra-ui/react";
+import { Avatar } from "../../components/ui/avatar";
+import { useColorModeValue } from "../../components/ui/color-mode";
 import { observer } from "mobx-react-lite";
 import { Profile } from "~/types";
 import FollowButton from "./FollowButton";

--- a/client-app/src/features/profiles/ProfileContent.tsx
+++ b/client-app/src/features/profiles/ProfileContent.tsx
@@ -1,16 +1,8 @@
-import {
-	GridItem,
-	Tab,
-	TabList,
-	TabPanel,
-	TabPanels,
-	Tabs,
-	useColorModeValue,
-} from "@chakra-ui/react";
+import { GridItem, Tabs } from "@chakra-ui/react";
 import { observer } from "mobx-react-lite";
-import React from "react";
 import { useStoreContext } from "~/stores/store";
-import { Profile } from "~/types";
+import type { Profile } from "~/types";
+import { useColorModeValue } from "../../components/ui/color-mode";
 import ProfileAbout from "./ProfileAbout";
 import ProfileActivities from "./ProfileActivities";
 import ProfileFollowings from "./ProfileFollowings";
@@ -22,47 +14,77 @@ type Props = {
 
 const ProfileContent = ({ profile }: Props) => {
 	const { profileStore } = useStoreContext();
+	const panelBg = useColorModeValue("gray.100", "gray.700");
 	return (
 		<GridItem colSpan={2}>
-			<Tabs
-				isLazy
+			<Tabs.Root
+				lazyMount
+				unmountOnExit
 				mt={6}
-				onChange={(idx) => profileStore.setActiveTab(idx)}
+				value={String(profileStore.activeTab)}
+				onValueChange={(e) => profileStore.setActiveTab(Number(e.value))}
 				orientation="vertical"
-				variant="solid-rounded"
-				colorScheme="twitter"
+				variant="enclosed"
+				colorPalette="twitter"
 			>
-				<TabPanels
+				<Tabs.List>
+					<Tabs.Trigger value="0">About</Tabs.Trigger>
+					<Tabs.Trigger value="1">Photos</Tabs.Trigger>
+					<Tabs.Trigger value="2">Events</Tabs.Trigger>
+					<Tabs.Trigger value="3">Followers</Tabs.Trigger>
+					<Tabs.Trigger value="4">Following</Tabs.Trigger>
+				</Tabs.List>
+				<Tabs.Content
+					value="0"
 					mr={6}
-					bgColor={useColorModeValue("gray.100", "gray.700")}
+					bgColor={panelBg}
 					borderRadius="lg"
 					boxShadow="md"
 					w="full"
 				>
-					<TabPanel>
-						<ProfileAbout />
-					</TabPanel>
-					<TabPanel w="full">
-						<ProfilePhotos profile={profile} />
-					</TabPanel>
-					<TabPanel>
-						<ProfileActivities />
-					</TabPanel>
-					<TabPanel>
-						<ProfileFollowings />
-					</TabPanel>
-					<TabPanel>
-						<ProfileFollowings />
-					</TabPanel>
-				</TabPanels>
-				<TabList>
-					<Tab>About</Tab>
-					<Tab>Photos</Tab>
-					<Tab>Events</Tab>
-					<Tab>Followers</Tab>
-					<Tab>Following</Tab>
-				</TabList>
-			</Tabs>
+					<ProfileAbout />
+				</Tabs.Content>
+				<Tabs.Content
+					value="1"
+					mr={6}
+					bgColor={panelBg}
+					borderRadius="lg"
+					boxShadow="md"
+					w="full"
+				>
+					<ProfilePhotos profile={profile} />
+				</Tabs.Content>
+				<Tabs.Content
+					value="2"
+					mr={6}
+					bgColor={panelBg}
+					borderRadius="lg"
+					boxShadow="md"
+					w="full"
+				>
+					<ProfileActivities />
+				</Tabs.Content>
+				<Tabs.Content
+					value="3"
+					mr={6}
+					bgColor={panelBg}
+					borderRadius="lg"
+					boxShadow="md"
+					w="full"
+				>
+					<ProfileFollowings />
+				</Tabs.Content>
+				<Tabs.Content
+					value="4"
+					mr={6}
+					bgColor={panelBg}
+					borderRadius="lg"
+					boxShadow="md"
+					w="full"
+				>
+					<ProfileFollowings />
+				</Tabs.Content>
+			</Tabs.Root>
 		</GridItem>
 	);
 };

--- a/client-app/src/features/profiles/ProfileEditForm.tsx
+++ b/client-app/src/features/profiles/ProfileEditForm.tsx
@@ -41,10 +41,10 @@ const ProfileEditForm = ({ setEditMode }: Props) => {
 		>
 			{({ isSubmitting, isValid, dirty, handleSubmit }) => (
 				<Form style={{ width: "100%" }} onSubmit={handleSubmit}>
-					<Flex mt={8} flexDir="column" w="full" experimental_spaceY={6}>
+					<Flex mt={8} flexDir="column" w="full" gap={6}>
 						<InputField placeholder="Display Name" name="displayName" />
 						<InputTextArea resize="vertical" rows={3} placeholder="Add your bio" name="bio" />
-						<Button type="submit" isLoading={isSubmitting} disabled={!isValid || !dirty}>
+						<Button type="submit" loading={isSubmitting} disabled={!isValid || !dirty}>
 							Update profile
 						</Button>
 					</Flex>

--- a/client-app/src/features/profiles/ProfileFollowings.tsx
+++ b/client-app/src/features/profiles/ProfileFollowings.tsx
@@ -12,7 +12,7 @@ const ProfileFollowings = () => {
 	}, [loadFollowings]);
 
 	return (
-		<VStack spacing={6} alignItems="start" w="full">
+		<VStack gap={6} alignItems="start" w="full">
 			<Flex justifyContent="space-between" w="full">
 				<Heading fontSize={"2xl"} textTransform="capitalize">
 					{activeTab === 3

--- a/client-app/src/features/profiles/ProfileHeader.tsx
+++ b/client-app/src/features/profiles/ProfileHeader.tsx
@@ -1,14 +1,14 @@
 import {
-	Avatar,
-	Divider,
+	Separator,
 	Flex,
 	GridItem,
 	Heading,
 	HStack,
 	Text,
-	useColorModeValue,
 	VStack,
 } from "@chakra-ui/react";
+import { Avatar } from "../../components/ui/avatar";
+import { useColorModeValue } from "../../components/ui/color-mode";
 import { observer } from "mobx-react-lite";
 import { Profile } from "~/types";
 import FollowButton from "./FollowButton";
@@ -37,11 +37,11 @@ const ProfileHeader = ({ profile }: Props) => {
 					<Heading ml={6}>{profile.displayName}</Heading>
 				</Flex>
 				<VStack>
-					<HStack mb={2} spacing={8}>
+					<HStack mb={2} gap={8}>
 						<StatBlock label="Followers" value={profile.followersCount} />
 						<StatBlock label="Following" value={profile.followingCount} />
 					</HStack>
-					<Divider />
+					<Separator />
 					{/* FOLLOW BUTTONS */}
 					<FollowButton profile={profile} />
 				</VStack>

--- a/client-app/src/features/profiles/ProfilePhotos.tsx
+++ b/client-app/src/features/profiles/ProfilePhotos.tsx
@@ -6,9 +6,9 @@ import {
 	Heading,
 	IconButton,
 	Image,
-	useColorModeValue,
 	VStack,
 } from "@chakra-ui/react";
+import { useColorModeValue } from "../../components/ui/color-mode";
 import { TrashIcon } from "@heroicons/react/24/solid";
 import { observer } from "mobx-react-lite";
 import React, { useState } from "react";
@@ -62,7 +62,7 @@ const ProfilePhotos = ({ profile }: Props) => {
 							<Box key={photo.id} flex="0 0 250px" pos="relative" bgColor={photoCardBgColor} p={4}>
 								<Image src={photo?.url} w={350} />
 								{photo?.isMain && (
-									<Badge pos="absolute" top={4} left={4} variant="solid" colorScheme="blue">
+									<Badge pos="absolute" top={4} left={4} variant="solid" colorPalette="blue">
 										Main
 									</Badge>
 								)}
@@ -70,24 +70,25 @@ const ProfilePhotos = ({ profile }: Props) => {
 									<Flex justifyContent="space-between" mt={4}>
 										<Button
 											size="sm"
-											colorScheme="blue"
+											colorPalette="blue"
 											name={"main" + photo.id}
 											onClick={(e) => handleSetMainPhoto(photo, e)}
-											isLoading={target === "main" + photo.id && isLoading}
-											isDisabled={photo.isMain}
+											loading={target === "main" + photo.id && isLoading}
+											disabled={photo.isMain}
 										>
 											Set Main
 										</Button>
 										<IconButton
 											aria-label={`delete ${photo.id}`}
-											icon={<TrashIcon width={16} />}
 											size="sm"
-											colorScheme="red"
+											colorPalette="red"
 											name={photo.id}
 											onClick={(e) => handleDeletePhoto(photo, e)}
-											isLoading={target === photo.id && isLoading}
-											isDisabled={photo.isMain}
-										/>
+											loading={target === photo.id && isLoading}
+											disabled={photo.isMain}
+										>
+											<TrashIcon width={16} />
+										</IconButton>
 									</Flex>
 								)}
 							</Box>

--- a/client-app/src/features/users/ConfirmEmail.tsx
+++ b/client-app/src/features/users/ConfirmEmail.tsx
@@ -1,8 +1,9 @@
-import { EmailIcon } from "@chakra-ui/icons";
-import { Button, Container, Flex, Heading, Text, useToast, VStack } from "@chakra-ui/react";
-import React, { useEffect, useState } from "react";
+import { EnvelopeIcon } from "@heroicons/react/24/outline";
+import { Button, Container, Flex, Heading, Text, VStack } from "@chakra-ui/react";
+import { useEffect, useState } from "react";
 import agent from "~/async/fetcher/agent";
 import useQuery from "~/hooks/useQuery";
+import { toaster } from "../../components/ui/toaster";
 import LoginModal from "./LoginModal";
 
 const Status = {
@@ -12,7 +13,6 @@ const Status = {
 };
 
 const ConfirmEmail = () => {
-	const toast = useToast();
 	const email = useQuery().get("email") as string;
 	const token = useQuery().get("token") as string;
 	const [status, setStatus] = useState(Status.Verifying);
@@ -20,9 +20,8 @@ const ConfirmEmail = () => {
 	const handleConfirmEmailResend = async () => {
 		try {
 			await agent.Account.resendEmailConfirm(email);
-			toast({
-				position: "bottom-right",
-				status: "success",
+			toaster.create({
+				type: "success",
 				title: "Email sent.",
 				description: "Verification email resent - please check your email.",
 			});
@@ -49,14 +48,14 @@ const ConfirmEmail = () => {
 				return <p>Verifying...</p>;
 			case Status.Failed:
 				return (
-					<VStack spacing={12}>
+					<VStack gap={12}>
 						<Text>Verification failed. You can try resending the verify link to your email</Text>
 						<Button onClick={handleConfirmEmailResend}>Resend Email</Button>
 					</VStack>
 				);
 			case Status.Success:
 				return (
-					<VStack spacing={12}>
+					<VStack gap={12}>
 						<Text>Email has been verified - you can now login</Text>
 						<LoginModal />
 					</VStack>
@@ -66,8 +65,8 @@ const ConfirmEmail = () => {
 
 	return (
 		<Container mx="auto" maxW="5xl" mt={100}>
-			<VStack spacing={4}>
-				<EmailIcon w={100} h={100} />
+			<VStack gap={4}>
+				<EnvelopeIcon width={100} height={100} />
 				<Heading>Email verification</Heading>
 			</VStack>
 			<Flex flexDir="column" mt={12}>

--- a/client-app/src/features/users/LoginForm.tsx
+++ b/client-app/src/features/users/LoginForm.tsx
@@ -1,4 +1,11 @@
-import { Box, Button, Heading, Text, useColorModeValue, VStack } from "@chakra-ui/react";
+import {
+	Box,
+	Button,
+	Heading,
+	Text,
+	VStack,
+} from "@chakra-ui/react";
+import { useColorModeValue } from "../../components/ui/color-mode";
 import { ErrorMessage, Form, Formik, FormikHelpers, FormikProps } from "formik";
 import { observer } from "mobx-react-lite";
 import InputField from "~/components/forms/Input";
@@ -41,12 +48,12 @@ const LoginForm = () => {
 			>
 				{({ handleSubmit, isSubmitting, dirty, isValid, errors }: FormikProps<LoginFormVals>) => (
 					<Form onSubmit={handleSubmit}>
-						<VStack spacing={6}>
+						<VStack gap={6}>
 							<Heading>Login to Reactivities</Heading>
 							<InputField name="email" type="email" />
 							<InputField name="password" type="password" />
 							{errors?.error && <Text>{errors?.error}</Text>}
-							<Button type="submit" isLoading={isSubmitting} disabled={!dirty || !isValid}>
+							<Button type="submit" loading={isSubmitting} disabled={!dirty || !isValid}>
 								Login
 							</Button>
 						</VStack>

--- a/client-app/src/features/users/LoginModal.tsx
+++ b/client-app/src/features/users/LoginModal.tsx
@@ -1,30 +1,37 @@
 import {
 	Button,
-	Modal,
-	ModalBody,
-	ModalCloseButton,
-	ModalContent,
-	ModalOverlay,
+	CloseButton,
+	Dialog,
+	Portal,
 	useDisclosure,
 } from "@chakra-ui/react";
 import LoginForm from "./LoginForm";
 
 const LoginModal = () => {
-	const { isOpen: isLoginOpen, onOpen: onLoginOpen, onClose: onLoginClose } = useDisclosure();
+	const { open, onOpen, onClose } = useDisclosure();
 	return (
 		<>
-			<Button onClick={onLoginOpen} variant="link">
+			<Button onClick={onOpen} variant="plain">
 				Login
 			</Button>
-			<Modal isOpen={isLoginOpen} onClose={onLoginClose}>
-				<ModalOverlay />
-				<ModalContent>
-					<ModalCloseButton />
-					<ModalBody>
-						<LoginForm />
-					</ModalBody>
-				</ModalContent>
-			</Modal>
+			<Dialog.Root
+				open={open}
+				onOpenChange={(e) => (e.open ? onOpen() : onClose())}
+			>
+				<Portal>
+					<Dialog.Backdrop />
+					<Dialog.Positioner>
+						<Dialog.Content>
+							<Dialog.CloseTrigger asChild>
+								<CloseButton size="sm" />
+							</Dialog.CloseTrigger>
+							<Dialog.Body>
+								<LoginForm />
+							</Dialog.Body>
+						</Dialog.Content>
+					</Dialog.Positioner>
+				</Portal>
+			</Dialog.Root>
 		</>
 	);
 };

--- a/client-app/src/features/users/RegisterForm.tsx
+++ b/client-app/src/features/users/RegisterForm.tsx
@@ -1,4 +1,10 @@
-import { Box, Button, Heading, useColorModeValue, VStack } from "@chakra-ui/react";
+import {
+	Box,
+	Button,
+	Heading,
+	VStack,
+} from "@chakra-ui/react";
+import { useColorModeValue } from "../../components/ui/color-mode";
 import { ErrorMessage, Form, Formik, FormikHelpers, FormikProps } from "formik";
 import { observer } from "mobx-react-lite";
 import * as yup from "yup";
@@ -38,7 +44,7 @@ const RegisterForm = () => {
 				{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
 				{({ handleSubmit, isSubmitting, dirty, isValid, errors }: FormikProps<any>) => (
 					<Form onSubmit={handleSubmit}>
-						<VStack spacing={6}>
+						<VStack gap={6}>
 							<Heading>Register</Heading>
 							<InputField name="displayName" type="text" />
 							<InputField name="username" type="text" />
@@ -49,9 +55,9 @@ const RegisterForm = () => {
 								render={() => <ValidationErrors errors={errors.error} />}
 							/>
 							<Button
-								colorScheme="green"
+								colorPalette="green"
 								type="submit"
-								isLoading={isSubmitting}
+								loading={isSubmitting}
 								disabled={!isValid || !dirty || isSubmitting}
 							>
 								Register

--- a/client-app/src/features/users/RegisterModal.tsx
+++ b/client-app/src/features/users/RegisterModal.tsx
@@ -1,35 +1,37 @@
-import React from "react";
 import {
 	Button,
-	Modal,
-	ModalBody,
-	ModalCloseButton,
-	ModalContent,
-	ModalOverlay,
+	CloseButton,
+	Dialog,
+	Portal,
 	useDisclosure,
 } from "@chakra-ui/react";
 import RegisterForm from "./RegisterForm";
 
 const RegisterModal = () => {
-	const {
-		isOpen: isRegisterOpen,
-		onOpen: onRegisterOpen,
-		onClose: onRegisterClose,
-	} = useDisclosure();
+	const { open, onOpen, onClose } = useDisclosure();
 	return (
 		<>
-			<Button onClick={onRegisterOpen} variant="link">
+			<Button onClick={onOpen} variant="plain">
 				Register
 			</Button>
-			<Modal isOpen={isRegisterOpen} onClose={onRegisterClose}>
-				<ModalOverlay />
-				<ModalContent>
-					<ModalCloseButton />
-					<ModalBody>
-						<RegisterForm />
-					</ModalBody>
-				</ModalContent>
-			</Modal>
+			<Dialog.Root
+				open={open}
+				onOpenChange={(e) => (e.open ? onOpen() : onClose())}
+			>
+				<Portal>
+					<Dialog.Backdrop />
+					<Dialog.Positioner>
+						<Dialog.Content>
+							<Dialog.CloseTrigger asChild>
+								<CloseButton size="sm" />
+							</Dialog.CloseTrigger>
+							<Dialog.Body>
+								<RegisterForm />
+							</Dialog.Body>
+						</Dialog.Content>
+					</Dialog.Positioner>
+				</Portal>
+			</Dialog.Root>
 		</>
 	);
 };

--- a/client-app/src/features/users/RegisterSuccess.tsx
+++ b/client-app/src/features/users/RegisterSuccess.tsx
@@ -1,17 +1,15 @@
-import { Box, Button, Container, Flex, Heading, Text, useToast } from "@chakra-ui/react";
-import React from "react";
+import { Box, Button, Container, Flex, Heading, Text } from "@chakra-ui/react";
 import agent from "~/async/fetcher/agent";
 import useQuery from "~/hooks/useQuery";
+import { toaster } from "../../components/ui/toaster";
 
 const RegisterSuccess = () => {
-	const toast = useToast();
 	const email = useQuery().get("email") as string;
 	const handleConfirmEmailResend = async () => {
 		try {
 			await agent.Account.resendEmailConfirm(email);
-			toast({
-				position: "bottom-right",
-				status: "success",
+			toaster.create({
+				type: "success",
 				title: "Email sent.",
 				description: "Verification email resent - please check your email.",
 			});
@@ -22,7 +20,7 @@ const RegisterSuccess = () => {
 	return (
 		<Box>
 			<Container mx="auto" my={20} maxW="5xl">
-				<Flex flexDir="column" experimental_spaceY={4}>
+				<Flex flexDir="column" gap={4}>
 					<Heading>Successfully Registered!</Heading>
 					<Text>Please Check your email (including junk folders) for the verification email.</Text>
 					{email && (

--- a/client-app/src/hooks/useAttachScripts.tsx
+++ b/client-app/src/hooks/useAttachScripts.tsx
@@ -1,14 +1,13 @@
-import { useToast } from "@chakra-ui/react";
 import { useNavigate } from "react-router-dom";
+import { toaster } from "../components/ui/toaster";
 
 export const useAttachScripts = () => {
 	const nav = useNavigate();
-	const toast = useToast();
 	if (!window.navigate) {
 		window.navigate = nav;
 	}
 
 	if (!window.toast) {
-		window.toast = toast;
+		window.toast = toaster.create;
 	}
 };

--- a/client-app/src/main.tsx
+++ b/client-app/src/main.tsx
@@ -1,7 +1,8 @@
-import { ChakraProvider } from "@chakra-ui/react";
 import ReactDOM from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import { router } from "./app/Router";
+import { Provider } from "./components/ui/provider";
+import { Toaster } from "./components/ui/toaster";
 import { StoreContextProvider } from "./stores/store";
 import "react-calendar/dist/Calendar.css";
 import "react-datepicker/dist/react-datepicker.css";
@@ -10,9 +11,10 @@ import "./styles/global.css";
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
 	<>
 		<StoreContextProvider>
-			<ChakraProvider resetCSS>
+			<Provider>
 				<RouterProvider router={router} />
-			</ChakraProvider>
+				<Toaster />
+			</Provider>
 		</StoreContextProvider>
 	</>,
 );

--- a/client-app/src/stores/activityStore.ts
+++ b/client-app/src/stores/activityStore.ts
@@ -1,5 +1,5 @@
 import { makeAutoObservable, reaction, runInAction } from "mobx";
-import agent from "src/async/fetcher/agent";
+import agent from "~/async/fetcher/agent";
 import type { Activity, PaginationHeader, User } from "~/types";
 import dayjs from "dayjs";
 import { store } from "./store";

--- a/client-app/src/types.d.ts
+++ b/client-app/src/types.d.ts
@@ -1,4 +1,4 @@
-import { UseToastOptions } from "@chakra-ui/react";
+import type { CreateToasterReturn } from "@chakra-ui/react";
 
 export interface PaginationHeader {
 	currentPage: number;
@@ -9,7 +9,7 @@ export interface PaginationHeader {
 
 declare global {
 	interface Window {
-		toast: (options?: UseToastOptions | undefined) => unknown;
+		toast: CreateToasterReturn["create"];
 		navigate: (url: string) => void;
 		FB: any;
 	}


### PR DESCRIPTION
## Summary

Completes the stalled Chakra UI v2→v3 migration so the production build compiles cleanly. Chakra was already at v3 (`3.35.0`) in `package.json`, but the source still used removed/renamed v2 APIs (~175 TS errors). All source usages are now migrated and `npm run build` (`tsc && vite build`) passes with exit code 0.

## Key API changes made

**Provider / system**
- New `ChakraProvider value={defaultSystem}` via a new `src/components/ui/provider.tsx` snippet; `main.tsx` now uses it and mounts `<Toaster />`.

**New v3 snippet components** (`src/components/ui/`)
- `color-mode.tsx` — self-contained `useColorMode`/`useColorModeValue` (context-based, no `next-themes` dependency added) replacing the removed v2 hooks.
- `toaster.tsx` — `createToaster` + `Toaster` replacing `useToast`.
- `field.tsx` — `Field.*` wrapper replacing the removed `FormControl`/`FormLabel`/`FormErrorMessage`.
- `avatar.tsx` — `Avatar.Root/Image/Fallback` wrapper (v3 Avatar is now a slot/namespaced component).

**Namespaced/slot component rewrites**
- `Modal.*` → `Dialog.*` (LoginModal, RegisterModal)
- `Menu.*`, `Popover.*` → namespaced Root/Trigger/Positioner/Content (+ Portal) (Navbar, DesktopNav, ListItemAttendee)
- `Tabs`/`Tab`/`TabList`/`TabPanels` → `Tabs.Root/List/Trigger/Content` with string `value` + `onValueChange` (ProfileContent, ProfileActivities)
- `Collapse` → `Collapsible.Root/Content` (Navbar, MobileNav)
- `UnorderedList`/`ListItem` → `List.Root`/`List.Item`
- `Divider` → `Separator`
- `Alert`/`AlertIcon` → `Alert.Root`/`Alert.Indicator`/`Alert.Content`
- `Select` (form) → `NativeSelect.Root`/`NativeSelect.Field`

**Icons**
- Removed `@chakra-ui/icons` usages; swapped for `@heroicons/react` equivalents (EmailIcon→EnvelopeIcon, HamburgerIcon→Bars3Icon, CloseIcon→XMarkIcon, Chevron*/Moon/Sun).

**Prop renames**
- `isOpen`→`open`, `isDisabled`→`disabled`, `isLoading`→`loading`, `isInvalid`→`invalid` (Field), `spacing`/`experimental_spaceY`→`gap`, `colorScheme`→`colorPalette`, `textColor`→`color`, `noOfLines`→`lineClamp`.
- `useDisclosure` now returns `open` (not `isOpen`).
- Polymorphic `as={Link} to=...` → `asChild` with a child `<Link>`/`<NavLink>` (typing no longer forwards arbitrary props).
- `IconButton icon={...}` → children; `ButtonGroup isAttached` → `Group attached`; `Spinner thickness/speed/emptyColor` → `borderWidth/animationDuration/color`.

**Non-Chakra fixes required for the build (also in the baseline 175 errors)**
- `activityStore.ts`: bad `src/...` import path → `~/` alias.
- `async/fetcher/index.ts`: axios request interceptor typed as `InternalAxiosRequestConfig`; toast calls use `type` instead of `status`/`position`.
- `InputDate.tsx`: `ReactDatePickerProps` → loosened props typing for react-datepicker v9's discriminated-union props.
- `window.toast` global type retargeted to `CreateToasterReturn["create"]`.

## Build status

`npm run build` in `client-app/` — PASS (exit 0). `tsc --noEmit` reports 0 errors (down from 175). `oxlint` shows only pre-existing warnings (no errors).

51 files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)